### PR TITLE
Fixed bug with incorrect shipping price treatment

### DIFF
--- a/src/components/com_jshopping/payments/pm_yandex_money/lib/Model/KassaPaymentMethod.php
+++ b/src/components/com_jshopping/payments/pm_yandex_money/lib/Model/KassaPaymentMethod.php
@@ -218,11 +218,12 @@ class KassaPaymentMethod
         }
 
         if ($order->shipping_method_id && $shipping) {
+            $shipping_price = $order->order_shipping;
             if (!empty($this->taxRates[$shipping->shipping_tax_id])) {
                 $taxId = $this->taxRates[$shipping->shipping_tax_id];
-                $builder->addReceiptShipping($shipping->name, $shipping->shipping_stand_price, $taxId);
+                $builder->addReceiptShipping($shipping->name, $shipping_price, $taxId);
             } else {
-                $builder->addReceiptShipping($shipping->name, $shipping->shipping_stand_price, $defaultTaxRate);
+                $builder->addReceiptShipping($shipping->name, $shipping_price, $defaultTaxRate);
             }
         }
     }


### PR DESCRIPTION
Before: "standard" shipping price from shipping object. Pure zero when calculated by extension via external API call.
After: real shipping price, including the amount calculated by additional price calculation extensions calling external APIs.